### PR TITLE
More efficient skipping of fixed size arrays

### DIFF
--- a/src/c-dvar-reader.c
+++ b/src/c-dvar-reader.c
@@ -484,6 +484,32 @@ static int c_dvar_ff(CDVar *var) {
                         assert(depth > 0);
                         --depth;
                         break;
+                case 'y':
+                case 'n':
+                case 'q':
+                case 'i':
+                case 'h':
+                case 'u':
+                case 'x':
+                case 't':
+                case 'd':
+                        /*
+                         * If we are skipping an entire array with a fixed size
+                         * member, we can jump over all members in one go. Note
+                         * that this only works if the member does not need any
+                         * validation (this excludes 'b' and any non-basic
+                         * type), because callers rely on this function to
+                         * check for content validity.
+                         */
+                        if (depth > 0 && var->current->container == 'a') {
+                                int t = var->current->n_buffer % var->current->i_type->size;
+                                var->current->i_buffer += var->current->n_buffer - t;
+                                var->current->n_buffer = t;
+
+                                c = ']';
+                                --depth;
+                        }
+                        break;
                 }
 
                 r = c_dvar_read(var, (char [2]){ c, 0 }, NULL);


### PR DESCRIPTION
This is based on what dbus-daemon does with fixed size arrays. It avoids calls to c_dvar_read() for each array element.

It also adds a large test to test-basic.c.

After adding the test, test-basic is executed (on my machine) for 1.2s without the change, and 0.6s with the change.