### PR TITLE
meson: no longer pass -Wl,--no-undefined explicitly

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -25,7 +25,6 @@ libcdvar_both = both_libraries(
         dependencies: libcdvar_deps,
         install: not meson.is_subproject(),
         link_args: [
-                '-Wl,--no-undefined',
                 '-Wl,--version-script=@0@'.format(libcdvar_symfile),
         ],
         link_depends: libcdvar_symfile,


### PR DESCRIPTION
to make it possible to build dbus-broker with clang and ASan/UBsan
on OSS-Fuzz (https://github.com/google/oss-fuzz/pull/7860) without
sed scripts.

-Wl,--no-undefined is still passed by meson by default unless -Db_lundef
is set to false explictily.

https://github.com/mesonbuild/meson/issues/764